### PR TITLE
Fix hardcoded config paths in Flatpak wrapper scripts

### DIFF
--- a/apply_extra.sh
+++ b/apply_extra.sh
@@ -57,6 +57,9 @@ sed -i "s/generic-icon name=\"wps-office-/generic-icon name=\"${FLATPAK_ID}./g" 
 # Fix hardcoded /opt paths in binaries
 sed -i 's|/opt|/app/extra/opt|' usr/bin/{et,misc,wpp,wps,wpspdf}
 
+# Fix hardcoded config paths in wrapper scripts for Flatpak's XDG config dir
+sed -i 's|${HOME}/.config|${XDG_CONFIG_HOME:-$HOME/.config}|g' usr/bin/{et,misc,wpp,wps,wpspdf}
+
 # use system libraries
 if [[ "$CARCH" = "aarch64" ]]; then
     rm opt/kingsoft/wps-office/office6/lib{jpeg,stdc++}.so*


### PR DESCRIPTION
This pull request makes a targeted improvement to the wrapper scripts for WPS Office in the Flatpak package. The main change ensures that configuration files are stored in the correct location according to Flatpak's use of the XDG config directory, rather than always defaulting to the user's `.config` directory.

- Flatpak compatibility:
  * Updated the wrapper scripts in `usr/bin/{et,misc,wpp,wps,wpspdf}` to use the `XDG_CONFIG_HOME` environment variable (falling back to `$HOME/.config` if not set), ensuring configuration files are stored in the correct location for Flatpak environments.

Fix #36 